### PR TITLE
feature: add _source support for search

### DIFF
--- a/pkg/core/index.go
+++ b/pkg/core/index.go
@@ -95,7 +95,6 @@ func (rindex *Index) BuildBlugeDocumentFromJSON(docID string, doc *map[string]in
 	}
 
 	if indexMappingNeedsUpdate {
-		indexMapping["@timestamp"] = "time" // time need date_histogram aggregation
 		rindex.SetMapping(indexMapping)
 	}
 
@@ -112,6 +111,9 @@ func (rindex *Index) BuildBlugeDocumentFromJSON(docID string, doc *map[string]in
 // iMap: a map of the fileds that specify name and type of the field. e.g. movietitle: string
 func (index *Index) SetMapping(iMap map[string]string) error {
 	bdoc := bluge.NewDocument(index.Name)
+
+	// @timestamp need date_range/date_histogram aggregation, and mappings used for type check in aggregation
+	iMap["@timestamp"] = "time"
 
 	for k, v := range iMap {
 		bdoc.AddField(bluge.NewTextField(k, v).StoreValue())

--- a/pkg/handlers/getindexmappings.go
+++ b/pkg/handlers/getindexmappings.go
@@ -23,14 +23,13 @@ func GetIndexMappings(c *gin.Context) {
 	}
 
 	// format mapping
-	properties := make(map[string]core.Properties)
+	properties := make(map[string]core.Properties, len(mappings))
 	for field, pType := range mappings {
+		if field == "_id" || field == "@timestamp" {
+			continue
+		}
 		properties[field] = core.Properties{Type: pType}
 	}
-
-	// delete internal field from mappings
-	delete(properties, "_id")
-	delete(properties, "@timestamp")
 
 	c.JSON(http.StatusOK, gin.H{"mappings": gin.H{"properties": properties}})
 }

--- a/pkg/handlers/listindexes.go
+++ b/pkg/handlers/listindexes.go
@@ -10,15 +10,22 @@ import (
 func ListIndexes(c *gin.Context) {
 	var indexListMap = make(map[string]*SimpleIndex)
 	for name, value := range core.ZINC_INDEX_LIST {
+		mappings := make(map[string]string, len(value.CachedMapping))
+		for field, pType := range value.CachedMapping {
+			if field == "_id" || field == "@timestamp" {
+				continue
+			}
+			mappings[field] = pType
+		}
 		indexListMap[name] = &SimpleIndex{
-			Name:          name,
-			CachedMapping: value.CachedMapping,
+			Name:     name,
+			Mappings: mappings,
 		}
 	}
 	c.JSON(http.StatusOK, indexListMap)
 }
 
 type SimpleIndex struct {
-	Name          string            `json:"name"`
-	CachedMapping map[string]string `json:"mapping"`
+	Name     string            `json:"name"`
+	Mappings map[string]string `json:"mapping"`
 }

--- a/pkg/meta/v1/types.go
+++ b/pkg/meta/v1/types.go
@@ -15,6 +15,7 @@ type ZincQuery struct {
 	Query        QueryParams                  `json:"query"`
 	Aggregations map[string]AggregationParams `json:"aggs"`
 	SortFields   []string                     `json:"sort_fields"`
+	Source       interface{}                  `json:"_source"`
 }
 
 type QueryParams struct {
@@ -48,6 +49,11 @@ type AggregationDateRange struct {
 type QueryHighlight struct {
 	Fields []string `json:"fields"`
 	Style  string   `json:"style"`
+}
+
+type Source struct {
+	Enable bool            // enable _source returns, default is true
+	Fields map[string]bool // what fields can returns
 }
 
 // SearchResponse for a query

--- a/pkg/uquery/source.go
+++ b/pkg/uquery/source.go
@@ -1,0 +1,35 @@
+package uquery
+
+import (
+	"encoding/json"
+
+	v1 "github.com/prabhatsharma/zinc/pkg/meta/v1"
+)
+
+func HandleSource(source *v1.Source, data []byte) map[string]interface{} {
+	ret := make(map[string]interface{})
+	// return empty
+	if !source.Enable {
+		return ret
+	}
+
+	err := json.Unmarshal(data, &ret)
+	if err != nil {
+		return nil
+	}
+
+	// return all fields
+	if len(source.Fields) == 0 {
+		return ret
+	}
+
+	// delete field not in source.Fields
+	for field := range ret {
+		if _, ok := source.Fields[field]; ok {
+			continue
+		}
+		delete(ret, field)
+	}
+
+	return ret
+}


### PR DESCRIPTION
now support pass `_source` to control returns fields for search.

 the implement like elasticsearch. it's support three options:

1. default, returns all fields of _source

```
{
"query_type": "matchall",
"_source": true
}
```

2. returns none fields of _source 

```
{
"query_type": "matchall",
"_source": false
}
```

3. returns custom fields of _source

```
{
"query_type": "matchall",
"_source": ["field1", "field2"]
}
```
